### PR TITLE
fix: remove minLength validation for lastName fields

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -192,8 +192,7 @@ export const ProfilePage: React.FC = () => {
                 <label className="form-label">Last Name *</label>
                 <input
                   {...register('lastName', { 
-                    required: 'Last name is required',
-                    minLength: { value: 2, message: 'Last name must be at least 2 characters' }
+                    required: 'Last name is required'
                   })}
                   type="text"
                   className="form-input"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -98,10 +98,6 @@ export const RegisterPage: React.FC = () => {
                 <input
                   {...register('lastName', {
                     required: 'Last name is required',
-                    minLength: {
-                      value: 2,
-                      message: 'Last name must be at least 2 characters'
-                    }
                   })}
                   type="text"
                   className="form-input"


### PR DESCRIPTION
The minLength validation was removed from lastName fields in both RegisterPage and ProfilePage to simplify user input requirements while maintaining the required field validation.